### PR TITLE
Fix Diagnostic Data Extraction and Stderr Capture

### DIFF
--- a/tofupy/schema.py
+++ b/tofupy/schema.py
@@ -276,9 +276,9 @@ class StreamLog:
 
             if line.get("type") == "diagnostic":
                 if line.get("@level") == "error":
-                    self.errors.append(Diagnostic(line))
+                    self.errors.append(Diagnostic(line.get("diagnostic", {})))
                 if line.get("@level") == "warning":
-                    self.warnings.append(Diagnostic(line))
+                    self.warnings.append(Diagnostic(line.get("diagnostic", {})))
                 continue
 
             if line.get("type") == "outputs":

--- a/tofupy/tofu.py
+++ b/tofupy/tofu.py
@@ -157,6 +157,7 @@ class Tofu:
             cwd=self.cwd,
             stdout=subprocess.PIPE,
             capture_output=False,
+            stderr=subprocess.PIPE,
             universal_newlines=True,
             encoding="utf-8",
             bufsize=1,


### PR DESCRIPTION
# Fix Diagnostic Data Extraction and Stderr Capture

This PR addresses two bugs in the OpenTofu streaming output handling:

## Changes

1. **Fixed Diagnostic Object Creation** (`schema.py`)
   - Corrected the `Diagnostic` instantiation to extract the nested `diagnostic` object from JSON events
   - Previously passed the entire event line instead of just the diagnostic data
   - Now properly accesses `line.get("diagnostic", {})` for both error and warning diagnostics

2. **Added Missing Stderr Capture** (`tofu.py`)
   - Added `stderr=subprocess.PIPE` to the `_run_stream` method
   - Ensures error output is properly captured during streaming operations
   - Prevents stderr from leaking to console during plan/apply operations

## Impact

- Diagnostic objects now correctly parse severity, summary, and detail fields
- Streaming commands (plan/apply) properly capture both stdout and stderr
- Improves error handling and debugging capabilities